### PR TITLE
TML-1816: Log hub faults

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
@@ -8,7 +8,7 @@ import okio.Buffer;
 
 public class SerialBuffer
 {
-    static final int DEFAULT_READ_BUFFER_SIZE = 16 * 1024;
+    static final int DEFAULT_READ_BUFFER_SIZE = 2 * 1024;
     static final int MAX_BULK_BUFFER = 16 * 1024;
     private ByteBuffer readBuffer;
 


### PR DESCRIPTION
When we receive a massive hub packet (kl27 memory dump is 32k) this buffer takes ~1.5 seconds to fill at 115200 baud.
Instead we would like to receive more frequent callbacks so we know there is still data arriving, as there is a 1.7 second timeout before the port is closed.