### PR TITLE
TML-3041: Missing USB data

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
@@ -101,8 +101,8 @@ public class SerialBuffer
         {
             if(src == null || src.length == 0) return;
 
-            if(debugging)
-                UsbSerialDebugger.printLogPut(src, true);
+//            if(debugging)
+//                UsbSerialDebugger.printLogPut(src, true);
 
             buffer.write(src);
             notify();
@@ -133,8 +133,8 @@ public class SerialBuffer
                 }
             }
 
-            if(debugging)
-                UsbSerialDebugger.printLogGet(dst, true);
+//            if(debugging)
+//                UsbSerialDebugger.printLogGet(dst, true);
 
             return dst;
         }

--- a/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
@@ -8,13 +8,13 @@ import okio.Buffer;
 
 public class SerialBuffer
 {
-    static final int DEFAULT_READ_BUFFER_SIZE = 2 * 1024;
+    static final int DEFAULT_READ_BUFFER_SIZE = 4 * 1024;
     static final int MAX_BULK_BUFFER = 16 * 1024;
     private ByteBuffer readBuffer;
 
     private final SynchronizedBuffer writeBuffer;
     private byte[] readBufferCompatible; // Read buffer for android < 4.2
-    private boolean debugging = false;
+    boolean debugging = false;
 
     public SerialBuffer(boolean version)
     {

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDebugger.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDebugger.java
@@ -6,24 +6,23 @@ import android.util.Log;
 
 public class UsbSerialDebugger
 {
-    private static final String CLASS_ID = UsbSerialDebugger.class.getSimpleName();
+    public static final String LOG_TAG = "UsbSerial";
     public static final String ENCODING = "UTF-8";
 
     private UsbSerialDebugger()
     {
-
     }
 
     public static void printLogGet(byte[] src, boolean verbose)
     {
         if(!verbose)
         {
-            Log.i(CLASS_ID, "Data obtained from write buffer: " + new String(src));
+            Log.i(LOG_TAG, "Data obtained from write buffer: " + new String(src));
         }else
         {
-            Log.i(CLASS_ID, "Data obtained from write buffer: " + new String(src));
-            Log.i(CLASS_ID, "Raw data from write buffer: " + HexData.hexToString(src));
-            Log.i(CLASS_ID, "Number of bytes obtained from write buffer: " + src.length);
+            Log.i(LOG_TAG, "Data obtained from write buffer: " + new String(src));
+            Log.i(LOG_TAG, "Raw data from write buffer: " + HexData.hexToString(src));
+            Log.i(LOG_TAG, "Number of bytes obtained from write buffer: " + src.length);
         }
     }
 
@@ -31,12 +30,12 @@ public class UsbSerialDebugger
     {
         if(!verbose)
         {
-            Log.i(CLASS_ID, "Data obtained pushed to write buffer: " + new String(src));
+            Log.i(LOG_TAG, "Data obtained pushed to write buffer: " + new String(src));
         }else
         {
-            Log.i(CLASS_ID, "Data obtained pushed to write buffer: " + new String(src));
-            Log.i(CLASS_ID, "Raw data pushed to write buffer: " + HexData.hexToString(src));
-            Log.i(CLASS_ID, "Number of bytes pushed from write buffer: " + src.length);
+            Log.i(LOG_TAG, "Data obtained pushed to write buffer: " + new String(src));
+            Log.i(LOG_TAG, "Raw data pushed to write buffer: " + HexData.hexToString(src));
+            Log.i(LOG_TAG, "Number of bytes pushed from write buffer: " + src.length);
         }
     }
 
@@ -44,12 +43,12 @@ public class UsbSerialDebugger
     {
         if(!verbose)
         {
-            Log.i(CLASS_ID, "Data obtained from Read buffer: " + new String(src));
+            Log.i(LOG_TAG, "Data obtained from Read buffer: " + new String(src));
         }else
         {
-            Log.i(CLASS_ID, "Data obtained from Read buffer: " + new String(src));
-            Log.i(CLASS_ID, "Raw data from Read buffer: " + HexData.hexToString(src));
-            Log.i(CLASS_ID, "Number of bytes obtained from Read buffer: " + src.length);
+            //Log.i(CLASS_ID, "Data obtained from Read buffer: " + new String(src));
+            Log.i(LOG_TAG, "Raw data from Read buffer: " + HexData.hexToString(src));
+            Log.i(LOG_TAG, "Number of bytes obtained from Read buffer: " + src.length);
         }
     }
 
@@ -57,15 +56,12 @@ public class UsbSerialDebugger
     {
         if(!verbose)
         {
-            Log.i(CLASS_ID, "Data obtained pushed to read buffer: " + new String(src));
+            Log.i(LOG_TAG, "Data obtained pushed to read buffer: " + new String(src));
         }else
         {
-            Log.i(CLASS_ID, "Data obtained pushed to read buffer: " + new String(src));
-            Log.i(CLASS_ID, "Raw data pushed to read buffer: " + HexData.hexToString(src));
-            Log.i(CLASS_ID, "Number of bytes pushed from read buffer: " + src.length);
+            Log.i(LOG_TAG, "Data obtained pushed to read buffer: " + new String(src));
+            Log.i(LOG_TAG, "Raw data pushed to read buffer: " + HexData.hexToString(src));
+            Log.i(LOG_TAG, "Number of bytes pushed from read buffer: " + src.length);
         }
     }
-
-
-
 }

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDebugger.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDebugger.java
@@ -6,7 +6,7 @@ import android.util.Log;
 
 public class UsbSerialDebugger
 {
-    public static final String LOG_TAG = "UsbSerial";
+    private static final String LOG_TAG = "UsbSerial";
     public static final String ENCODING = "UTF-8";
 
     private UsbSerialDebugger()

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
@@ -347,7 +347,9 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
             {
                 byte[] data = serialBuffer.getDataReceived();
                 if (serialBuffer.debugging) {
-                    Log.i(LOG_TAG, "Time since last read: " + (SystemClock.elapsedRealtime() - timeLastDataReceived));
+                    if (timeLastDataReceived > 0) {
+                        Log.i(LOG_TAG, "Time since last read: " + (SystemClock.elapsedRealtime() - timeLastDataReceived));
+                    }
                     timeLastDataReceived = SystemClock.elapsedRealtime();
                 }
 

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
@@ -346,7 +346,7 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
             {
                 byte[] data = serialBuffer.getDataReceived();
                 if (serialBuffer.debugging) {
-                    Log.e("UsbSerialDevice", "Time since last read: " + (SystemClock.elapsedRealtime() - timeLastDataReceived));
+                    Log.i("UsbSerialDevice", "Time since last read: " + (SystemClock.elapsedRealtime() - timeLastDataReceived));
                     timeLastDataReceived = SystemClock.elapsedRealtime();
                 }
 

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
@@ -17,6 +17,7 @@ import android.util.Log;
 
 public abstract class UsbSerialDevice implements UsbSerialInterface
 {
+    public static final String LOG_TAG = "UsbSerial";
     public static final String CDC = "cdc";
     public static final String CH34x = "ch34x";
     public static final String CP210x = "cp210x";
@@ -339,14 +340,14 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
             try {
                 request = connection.requestWait();
             } catch (Exception e) {
-                Log.e("UsbSerialDevice", "Error requesting USB connection: "+ e.getMessage());
+                Log.e(LOG_TAG, "Error requesting USB connection: "+ e.getMessage());
             }
             if(request != null && request.getEndpoint().getType() == UsbConstants.USB_ENDPOINT_XFER_BULK
                     && request.getEndpoint().getDirection() == UsbConstants.USB_DIR_IN)
             {
                 byte[] data = serialBuffer.getDataReceived();
                 if (serialBuffer.debugging) {
-                    Log.i("UsbSerialDevice", "Time since last read: " + (SystemClock.elapsedRealtime() - timeLastDataReceived));
+                    Log.i(LOG_TAG, "Time since last read: " + (SystemClock.elapsedRealtime() - timeLastDataReceived));
                     timeLastDataReceived = SystemClock.elapsedRealtime();
                 }
 

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
@@ -12,6 +12,7 @@ import android.hardware.usb.UsbEndpoint;
 import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbRequest;
 import android.os.Build;
+import android.os.SystemClock;
 import android.util.Log;
 
 public abstract class UsbSerialDevice implements UsbSerialInterface
@@ -323,10 +324,12 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
 
         private UsbReadCallback callback;
         private UsbRequest requestIN;
+        private Long timeLastDataReceived = 0L;
 
         public WorkerThread(UsbSerialDevice usbSerialDevice)
         {
             this.usbSerialDevice = usbSerialDevice;
+            this.setPriority(Thread.MAX_PRIORITY);
         }
 
         @Override
@@ -342,6 +345,10 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
                     && request.getEndpoint().getDirection() == UsbConstants.USB_DIR_IN)
             {
                 byte[] data = serialBuffer.getDataReceived();
+                if (serialBuffer.debugging) {
+                    Log.e("UsbSerialDevice", "Time since last read: " + (SystemClock.elapsedRealtime() - timeLastDataReceived));
+                    timeLastDataReceived = SystemClock.elapsedRealtime();
+                }
 
                 // FTDI devices reserves two first bytes of an IN endpoint with info about
                 // modem and Line.


### PR DESCRIPTION
USB data is sometimes being dropped, causing hub frame checksum errors in the TML frame parser..
Not sure exactly what is going on (apart from general interference probably).

This PR increases the buffer size and changes USB read thread priority to max in case that helps.